### PR TITLE
fix/responsive-template-issues

### DIFF
--- a/src/docs/alerts.md
+++ b/src/docs/alerts.md
@@ -76,9 +76,9 @@
 ## Dismissing
 
 <code-preview>
-  <div class="relative px-5 py-3 mt-4 text-base text-yellow-800 bg-yellow-200 border border-yellow-300 border-solid rounded pr-9" role="alert">
-    <strong>Holy guacamole!</strong> You should check in on some of those fields below.
-    <button type="button" class="absolute inset-y-0 right-0 block px-4 text-2xl font-semibold text-yellow-600" data-dismiss="alert" aria-label="Close">
+  <div role="alert" class="grid items-center justify-between grid-flow-col px-5 py-3 mt-4 text-base text-yellow-800 bg-yellow-200 border border-yellow-300 border-solid rounded pr-9">
+    <p class="m-0"><strong>Holy guacamole!</strong> You should check in on some of those fields below.</p>
+    <button type="button" data-dismiss="alert" aria-label="Close" class="block w-8 h-full text-2xl font-semibold text-yellow-600">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>

--- a/src/docs/buttons.md
+++ b/src/docs/buttons.md
@@ -4,15 +4,15 @@
 
 <code-preview>
   <template>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none">Primary</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:outline-none">Secondary</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-green-500 border-transparent border-solid rounded cursor-pointer hover:bg-green-600 active:bg-green-600 focus:outline-none">Success</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-red-600 border-transparent border-solid rounded cursor-pointer hover:bg-red-700 active:bg-red-700 focus:outline-none">Danger</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center align-middle bg-yellow-500 border-transparent border-solid rounded cursor-pointer text-dark hover:bg-yellow-600 active:bg-yellow-600 focus:outline-none">Warning</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-teal-500 border-transparent border-solid rounded cursor-pointer hover:bg-teal-600 active:bg-teal-600 focus:outline-none">Info</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center align-middle bg-gray-200 border-transparent border-solid rounded cursor-pointer text-dark hover:bg-gray-300 active:bg-gray-300 focus:outline-none">Light</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-gray-800 border-transparent border-solid rounded cursor-pointer hover:bg-gray-900 active:bg-gray-900 focus:outline-none">Dark</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-blue-600 align-middle border-transparent border-solid rounded cursor-pointer hover:text-blue-700 active:text-blue-700 hover:underline active:underline focus:outline-none">Link</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none">Primary</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:outline-none">Secondary</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-green-500 border-transparent border-solid rounded cursor-pointer hover:bg-green-600 active:bg-green-600 focus:outline-none">Success</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-red-600 border-transparent border-solid rounded cursor-pointer hover:bg-red-700 active:bg-red-700 focus:outline-none">Danger</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center align-middle bg-yellow-500 border-transparent border-solid rounded cursor-pointer text-dark hover:bg-yellow-600 active:bg-yellow-600 focus:outline-none">Warning</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-teal-500 border-transparent border-solid rounded cursor-pointer hover:bg-teal-600 active:bg-teal-600 focus:outline-none">Info</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center align-middle bg-gray-200 border-transparent border-solid rounded cursor-pointer text-dark hover:bg-gray-300 active:bg-gray-300 focus:outline-none">Light</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-gray-800 border-transparent border-solid rounded cursor-pointer hover:bg-gray-900 active:bg-gray-900 focus:outline-none">Dark</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-blue-600 align-middle border-transparent border-solid rounded cursor-pointer hover:text-blue-700 active:text-blue-700 hover:underline active:underline focus:outline-none">Link</button>
   </template>
 </code-preview>
 
@@ -20,11 +20,11 @@
 
 <code-preview>
   <template>
-    <a href="#!" role="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:no-underline hover:bg-blue-700 active:no-underline active:bg-blue-700 focus:outline-none">Primary</a>
-    <button class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="submit">Button</button>
-    <input class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="button" value="Input">
-    <input class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="submit" value="Submit">
-    <input class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="reset" value="Reset">
+    <a href="#!" role="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:no-underline hover:bg-blue-700 active:no-underline active:bg-blue-700 focus:outline-none">Primary</a>
+    <button class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="submit">Button</button>
+    <input class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="button" value="Input">
+    <input class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="submit" value="Submit">
+    <input class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:outline-none" type="reset" value="Reset">
   </template>
 </code-preview>
 
@@ -32,14 +32,14 @@
 
 <code-preview>
   <template>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-blue-600 align-middle transition-colors duration-200 border border-blue-600 border-solid rounded cursor-pointer hover:text-white hover:bg-blue-600 active:text-white active:bg-blue-600 focus:outline-none">Primary</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-gray-600 align-middle transition-colors duration-200 border border-gray-600 border-solid rounded cursor-pointer hover:text-white hover:bg-gray-600 active:text-white active:bg-gray-600 focus:outline-none">Secondary</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-green-500 align-middle transition-colors duration-200 border border-green-500 border-solid rounded cursor-pointer hover:text-white hover:bg-green-500 active:text-white active:bg-green-500 focus:outline-none">Success</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-red-600 align-middle transition-colors duration-200 border border-red-600 border-solid rounded cursor-pointer hover:text-white hover:bg-red-600 active:text-white active:bg-red-600 focus:outline-none">Danger</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-yellow-500 align-middle transition-colors duration-200 border border-yellow-500 border-solid rounded cursor-pointer hover:text-black hover:bg-yellow-500 active:text-black active:bg-yellow-500 focus:outline-none">Warning</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-teal-500 align-middle transition-colors duration-200 border border-teal-500 border-solid rounded cursor-pointer hover:text-white hover:bg-teal-500 active:text-white active:bg-teal-500 focus:outline-none">Info</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-gray-200 align-middle transition-colors duration-200 border border-gray-200 border-solid rounded cursor-pointer hover:text-black hover:bg-gray-200 active:text-black active:bg-gray-200 focus:outline-none">Light</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-gray-800 align-middle transition-colors duration-200 border border-gray-800 border-solid rounded cursor-pointer hover:text-white hover:bg-gray-800 active:text-white active:bg-gray-800 focus:outline-none">Dark</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-blue-600 align-middle transition-colors duration-200 border border-blue-600 border-solid rounded cursor-pointer hover:text-white hover:bg-blue-600 active:text-white active:bg-blue-600 focus:outline-none">Primary</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-gray-600 align-middle transition-colors duration-200 border border-gray-600 border-solid rounded cursor-pointer hover:text-white hover:bg-gray-600 active:text-white active:bg-gray-600 focus:outline-none">Secondary</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-green-500 align-middle transition-colors duration-200 border border-green-500 border-solid rounded cursor-pointer hover:text-white hover:bg-green-500 active:text-white active:bg-green-500 focus:outline-none">Success</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-red-600 align-middle transition-colors duration-200 border border-red-600 border-solid rounded cursor-pointer hover:text-white hover:bg-red-600 active:text-white active:bg-red-600 focus:outline-none">Danger</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-yellow-500 align-middle transition-colors duration-200 border border-yellow-500 border-solid rounded cursor-pointer hover:text-black hover:bg-yellow-500 active:text-black active:bg-yellow-500 focus:outline-none">Warning</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-teal-500 align-middle transition-colors duration-200 border border-teal-500 border-solid rounded cursor-pointer hover:text-white hover:bg-teal-500 active:text-white active:bg-teal-500 focus:outline-none">Info</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-gray-200 align-middle transition-colors duration-200 border border-gray-200 border-solid rounded cursor-pointer hover:text-black hover:bg-gray-200 active:text-black active:bg-gray-200 focus:outline-none">Light</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-gray-800 align-middle transition-colors duration-200 border border-gray-800 border-solid rounded cursor-pointer hover:text-white hover:bg-gray-800 active:text-white active:bg-gray-800 focus:outline-none">Dark</button>
   </template>
 </code-preview>
 
@@ -47,29 +47,29 @@
 
 <code-preview>
   <template>
-    <button type="button" class="inline-block px-4 py-2 text-xl font-normal leading-8 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Large button</button>
-    <button type="button" class="inline-block px-4 py-2 text-xl font-normal leading-8 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Large button</button>
+    <button type="button" class="inline-block px-4 py-2 m-1 text-xl font-normal leading-8 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Large button</button>
+    <button type="button" class="inline-block px-4 py-2 m-1 text-xl font-normal leading-8 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Large button</button>
   </template>
 </code-preview>
 
 <code-preview>
   <template>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Normal button</button>
-    <button type="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Normal button</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Normal button</button>
+    <button type="button" class="inline-block px-3 py-2 m-1 text-base font-normal leading-6 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Normal button</button>
   </template>
 </code-preview>
 
 <code-preview>
   <template>
-    <button type="button" class="inline-block px-2 py-1 text-sm font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Small button</button>
-    <button type="button" class="inline-block px-2 py-1 text-sm font-normal leading-6 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Small button</button>
+    <button type="button" class="inline-block px-2 py-1 m-1 text-sm font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Small button</button>
+    <button type="button" class="inline-block px-2 py-1 m-1 text-sm font-normal leading-6 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Small button</button>
   </template>
 </code-preview>
 
 <code-preview>
   <template>
-    <button type="button" class="block w-full px-4 py-2 mt-2 text-xl font-normal leading-8 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Block level button</button>
-    <button type="button" class="block w-full px-4 py-2 mt-2 text-xl font-normal leading-8 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Block level button</button>
+    <button type="button" class="block w-full px-4 py-2 m-1 text-xl font-normal leading-8 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none">Block level button</button>
+    <button type="button" class="block w-full px-4 py-2 m-1 text-xl font-normal leading-8 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded-md cursor-pointer hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none">Block level button</button>
   </template>
 </code-preview>
 
@@ -77,7 +77,7 @@
 
 <code-preview>
   <template>
-    <button type="button" class="inline-block px-4 py-2 text-xl font-normal leading-8 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded-md cursor-pointer disabled:cursor-not-allowed hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none disabled:opacity-75" disabled>Large button</button>
-    <button type="button" class="inline-block px-4 py-2 text-xl font-normal leading-8 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded-md cursor-pointer disabled:cursor-not-allowed hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none disabled:opacity-75" disabled>Large button</button>
+    <button type="button" class="inline-block px-4 py-2 m-1 text-xl font-normal leading-8 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded-md cursor-pointer disabled:cursor-not-allowed hover:bg-blue-700 active:bg-blue-700 focus:bg-blue-700 focus:outline-none disabled:opacity-75" disabled>Large button</button>
+    <button type="button" class="inline-block px-4 py-2 m-1 text-xl font-normal leading-8 text-center text-white align-middle bg-gray-600 border-transparent border-solid rounded-md cursor-pointer disabled:cursor-not-allowed hover:bg-gray-700 active:bg-gray-700 focus:bg-gray-700 focus:outline-none disabled:opacity-75" disabled>Large button</button>
   </template>
 </code-preview>

--- a/src/docs/card.md
+++ b/src/docs/card.md
@@ -5,7 +5,7 @@
 <code-preview>
   <template>
     <div class="flex flex-col w-full overflow-auto bg-white border border-gray-400 rounded sm:w-2/5">
-      <div class="h-1/3"><img src="https://picsum.photos/500/250" alt="placeholder" class="object-cover min-w-full" /></div>
+      <img src="https://picsum.photos/500/250" alt="placeholder" class="object-cover h-48 min-w-full" />
       <div class="p-4 h-2/3">
         <h5 class="mb-3 text-xl font-medium">Card With top Image</h5>
         <p class="mb-4">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
@@ -23,7 +23,7 @@
         <p class="mb-4">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
         <a href="#!" role="button" class="inline-block px-3 py-2 text-base font-normal leading-6 text-center text-white align-middle bg-blue-600 border-transparent border-solid rounded cursor-pointer hover:bg-blue-700 hover:no-underline focus:outline-none active:bg-blue-700 active:no-underline">Go somewhere</a>
       </div>
-      <div class="h-1/3"><img src="https://picsum.photos/500/250" alt="placeholder" class="object-cover min-w-full" /></div>
+      <img src="https://picsum.photos/500/250" alt="placeholder" class="object-cover h-48 min-w-full" />
     </div>
   </template>
 </code-preview>

--- a/src/docs/navs.md
+++ b/src/docs/navs.md
@@ -83,9 +83,6 @@
         <a class="inline-block px-4 py-3 text-base font-normal leading-6 text-blue-600 no-underline align-middle border-t border-b-0 border-l border-r border-transparent border-solid cursor-pointer focus:border-gray-400 rounded-t-md hover:text-blue-700 focus:outline-none active:text-blue-700" href="#">Link</a>
       </li>
       <li>
-        <a class="inline-block px-4 py-3 text-base font-normal leading-6 text-blue-600 no-underline align-middle border-t border-b-0 border-l border-r border-transparent border-solid cursor-pointer focus:border-gray-400 rounded-t-md hover:text-blue-700 focus:outline-none active:text-blue-700" href="#">Link</a>
-      </li>
-      <li>
         <a class="inline-block px-4 py-3 text-base font-normal leading-6 text-gray-600 no-underline align-middle border-t border-b-0 border-l border-r border-transparent border-solid cursor-not-allowed pointer-events-none focus:border-gray-400 rounded-t-md hover:gray-blue-700 focus:outline-none active:text-gray-700">Disabled</a>
       </li>
     </ul>


### PR DESCRIPTION
- Fix dismissing alert template to use grid instead of abosulte positioning for resposive issues and better layout.
- Add a small margin to all button templates so they can be spaced out when wraping on new lines.
- Set a base height for basic card images to avoid page jumps when images load and also make the images bound to a fixed height.
- Fix tabs template on mobile screens.